### PR TITLE
docs: author spec.documentation and spec.examples in agent.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,26 @@ infer agents add grafana-agent http://localhost:8080 \
 | `create_dashboard` | Creates a Grafana dashboard with specified panels, queries, and configurations | dashboard_title, deploy, description, grafana_url, panels, refresh_interval, tags, time_range, variables |
 | `deploy_dashboard` | Deploys a dashboard JSON to Grafana (Cloud or self-hosted) | dashboard_json, folder_uid, grafana_url, message, overwrite |
 
+## Examples
+
+| Example | Description |
+|---------|-------------|
+| Discover metrics for a service | Ask "What HTTP metrics are exposed in Prometheus matching http_.*?" and the agent uses discover_metrics to list the matching series, optionally filtered by metric type (counter, gauge, histogram, summary). |
+| Build and validate a PromQL query | Ask "Give me the p99 request latency per endpoint" and the agent drafts PromQL with generate_promql_queries, applies the promql skill's best practices, and confirms it parses against Prometheus with validate_promql_query before returning it. |
+| Create a dashboard for a service | Ask "Create a RED-method dashboard for my checkout service" and the agent uses the dashboarding skill and create_dashboard to assemble time series and stat panels wired to validated PromQL queries, with thresholds and template variables. |
+| Deploy a dashboard to Grafana | Provide a Grafana URL and API key, then ask "Deploy this dashboard to my Grafana Cloud instance" and the agent pushes the dashboard JSON with deploy_dashboard (guarded by GRAFANA_DEPLOY_ENABLED) to Grafana Cloud or a self-hosted instance. |
+
 ## Skills (loaded into the system prompt)
 
 | Skill | Description | Source |
 |-------|-------------|--------|
 | `promql` | Write, validate, and optimise PromQL queries for Prometheus and Grafana Cloud Metrics. Use when the user asks to query metrics, write a PromQL expression, calculate rates, aggregate across labels, build histogram quantiles, create recording rules, debug query performance, or understand metric cardinality. Triggers on phrases like "PromQL", "Prometheus query", "write a metric query", "calculate rate", "histogram_quantile", "recording rule", "metric cardinality", "sum by", "rate vs irate", "absent()", or "query is slow". | registry @ 6311c4f4d36db3c5a85686ef2b3ce5fed4e53c0c |
 | `dashboarding` | Create, modify, and organise Grafana dashboards including panels, variables, transformations, and alerting. Use when the user asks to create a Grafana dashboard, add a panel, configure a time series or stat panel, add template variables, set up dashboard linking, use transformations, configure thresholds, build a dashboard for a service, or export dashboard JSON. Triggers on phrases like "create dashboard", "add panel", "time series panel", "Grafana dashboard JSON", "template variables", "dashboard variable", "panel transformation", "threshold", "stat panel", "table panel", "Grafana annotations", or "dashboard folder". | registry @ 6311c4f4d36db3c5a85686ef2b3ce5fed4e53c0c |
+
+## Documentation
+- [Getting Started](docs/getting-started.md)
+- [Configuration](docs/configuration.md)
+- [Usage](docs/usage.md)
 
 ## Configuration
 

--- a/agent.yaml
+++ b/agent.yaml
@@ -213,6 +213,47 @@ spec:
       source: https://github.com/grafana/skills/tree/6311c4f4d36db3c5a85686ef2b3ce5fed4e53c0c/skills/grafana-core/promql
     - id: dashboarding
       source: https://github.com/grafana/skills/tree/6311c4f4d36db3c5a85686ef2b3ce5fed4e53c0c/skills/grafana-core/dashboarding
+  examples:
+    - title: Discover metrics for a service
+      description: >-
+        Ask "What HTTP metrics are exposed in Prometheus matching http_.*?" and
+        the agent uses discover_metrics to list the matching series, optionally
+        filtered by metric type (counter, gauge, histogram, summary).
+    - title: Build and validate a PromQL query
+      description: >-
+        Ask "Give me the p99 request latency per endpoint" and the agent drafts
+        PromQL with generate_promql_queries, applies the promql skill's best
+        practices, and confirms it parses against Prometheus with
+        validate_promql_query before returning it.
+    - title: Create a dashboard for a service
+      description: >-
+        Ask "Create a RED-method dashboard for my checkout service" and the
+        agent uses the dashboarding skill and create_dashboard to assemble time
+        series and stat panels wired to validated PromQL queries, with
+        thresholds and template variables.
+    - title: Deploy a dashboard to Grafana
+      description: >-
+        Provide a Grafana URL and API key, then ask "Deploy this dashboard to my
+        Grafana Cloud instance" and the agent pushes the dashboard JSON with
+        deploy_dashboard (guarded by GRAFANA_DEPLOY_ENABLED) to Grafana Cloud or
+        a self-hosted instance.
+  documentation:
+    pages:
+      - title: Getting Started
+        path: docs/getting-started.md
+        description: >-
+          Run the agent, connect it to an LLM, Prometheus, and Grafana, and send
+          your first request.
+      - title: Configuration
+        path: docs/configuration.md
+        description: >-
+          Environment variables for the LLM client, Prometheus, and Grafana
+          deployment.
+      - title: Usage
+        path: docs/usage.md
+        description: >-
+          The discover, query, build, and deploy workflow and the tools behind
+          it.
   server:
     port: 8080
     debug: false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,52 @@
+# Configuration
+
+All configuration is supplied through environment variables. The tables below
+cover the settings this agent reads directly; the project
+[README](../README.md#configuration) documents the full A2A server variable
+list (`A2A_*`).
+
+## LLM client
+
+The agent defers to an OpenAI-compatible LLM client.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `A2A_AGENT_CLIENT_PROVIDER` | Provider: `openai`, `anthropic`, `azure`, `ollama`, `deepseek` | |
+| `A2A_AGENT_CLIENT_MODEL` | Model identifier | |
+| `A2A_AGENT_CLIENT_API_KEY` | Provider API key | |
+| `A2A_AGENT_CLIENT_BASE_URL` | Custom endpoint, e.g. an Inference Gateway | |
+
+## Prometheus
+
+The `discover_metrics`, `generate_promql_queries`, and `validate_promql_query`
+tools each take a `prometheus_url` argument on the call. When a request does
+not specify one, the agent's system prompt falls back to a default of
+`http://prometheus.grafana-agent.svc.cluster.local:9090`. The
+[Kubernetes example](../examples/kubernetes/README.md) also exposes a matching
+`PROMETHEUS_URL` environment variable so deployments can advertise the endpoint
+in one place.
+
+## Grafana
+
+The `create_dashboard` and `deploy_dashboard` tools read these settings from
+`spec.config.grafana` in `agent.yaml` (env prefix `GRAFANA_`). Deployment is
+disabled by default, so a dashboard is only pushed to Grafana when you
+explicitly opt in.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `GRAFANA_URL` | Grafana base URL (Cloud or self-hosted) | |
+| `GRAFANA_API_KEY` | Grafana API key / service-account token | |
+| `GRAFANA_ORG_ID` | Grafana organisation ID | |
+| `GRAFANA_DEPLOY_ENABLED` | Allow `deploy_dashboard` / `create_dashboard` to push to Grafana | `false` |
+
+Deploying a dashboard requires both `GRAFANA_DEPLOY_ENABLED=true` and a
+configured `GRAFANA_API_KEY`; the tools return an error otherwise. A
+`grafana_url` argument on the tool call overrides `GRAFANA_URL` for that
+request.
+
+## Built-in tools
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TOOLS_READ_ENABLED` | Enable the built-in `read` tool used to load skill playbooks | `true` |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,73 @@
+# Getting Started
+
+`grafana-agent` is an [A2A](https://github.com/inference-gateway/adk) server
+that turns natural-language requests into Prometheus queries and Grafana
+dashboards. This guide gets a local instance running and answering requests.
+
+## Prerequisites
+
+- Go 1.26.4+ (or Docker) to run the agent.
+- An API key for an LLM provider (`openai`, `anthropic`, `azure`, `ollama`,
+  or `deepseek`).
+- A reachable Prometheus server — required by the metric and PromQL tools.
+- A Grafana instance with an API key — only needed to deploy dashboards.
+
+## Run the agent
+
+The generated binary is a CLI; `start` boots the A2A server.
+
+```bash
+# From source
+go run . start
+
+# Or build the CLI and run it
+task build
+./bin/grafana-agent start
+
+# Or with Docker
+docker build -t grafana-agent .
+docker run -p 8080:8080 grafana-agent
+```
+
+The server listens on port `8080` by default (override with `A2A_PORT`).
+
+## Connect an LLM
+
+The agent needs an LLM provider to reason over requests:
+
+```bash
+export A2A_AGENT_CLIENT_PROVIDER=deepseek
+export A2A_AGENT_CLIENT_MODEL=deepseek-v4-flash
+export A2A_AGENT_CLIENT_API_KEY=<your-key>
+```
+
+See [Configuration](configuration.md) for the full list of variables,
+including the Prometheus and Grafana settings the tools rely on.
+
+## Send your first request
+
+Confirm the agent is healthy and inspect its capabilities:
+
+```bash
+curl http://localhost:8080/health
+curl http://localhost:8080/.well-known/agent-card.json
+```
+
+Then submit a task with the
+[A2A Debugger](https://github.com/inference-gateway/a2a-debugger):
+
+```bash
+docker run --rm -it --network host \
+  ghcr.io/inference-gateway/a2a-debugger:latest \
+  --server-url http://localhost:8080 \
+  tasks submit "Discover the HTTP metrics available in Prometheus"
+```
+
+For a full local stack (agent + Grafana + Prometheus + a demo service), see the
+[docker-compose example](../examples/docker-compose/README.md). A Kubernetes
+walkthrough lives in the [kubernetes example](../examples/kubernetes/README.md).
+
+## Next steps
+
+- [Configuration](configuration.md) — every environment variable this agent reads.
+- [Usage](usage.md) — the discover → query → build → deploy workflow.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,62 @@
+# Usage
+
+`grafana-agent` turns natural-language requests into Prometheus queries and
+Grafana dashboards. A typical request flows through four steps, backed by the
+agent's tools and skills.
+
+## The workflow
+
+1. **Discover** — `discover_metrics` lists the metrics a Prometheus server
+   exposes, optionally filtered by a name regex or metric type (counter, gauge,
+   histogram, summary).
+2. **Query** — `generate_promql_queries` suggests PromQL for chosen metrics
+   using Prometheus metadata, and `validate_promql_query` checks that an
+   expression parses against the server. The **promql** skill guides rate
+   selection, aggregation, and `histogram_quantile` usage.
+3. **Build** — `create_dashboard` assembles a Grafana dashboard from panels,
+   queries, thresholds, and template variables. The **dashboarding** skill
+   supplies panel and layout best practices.
+4. **Deploy** — `deploy_dashboard` (or `create_dashboard` with `deploy: true`)
+   pushes the dashboard JSON to Grafana Cloud or a self-hosted instance, gated
+   on `GRAFANA_DEPLOY_ENABLED=true` (see [Configuration](configuration.md)).
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `discover_metrics` | Discover metrics from a Prometheus endpoint with optional name/type filtering |
+| `generate_promql_queries` | Generate PromQL suggestions for given metric names |
+| `validate_promql_query` | Validate a PromQL query against Prometheus |
+| `create_dashboard` | Build a Grafana dashboard with panels, queries, and variables |
+| `deploy_dashboard` | Deploy a dashboard JSON to Grafana (Cloud or self-hosted) |
+| `Read` | Load a skill playbook (`SKILL.md`) on demand |
+
+## Skills
+
+Two markdown playbooks are loaded into the system prompt and read on demand:
+
+- **promql** — writing, validating, and optimising PromQL queries.
+- **dashboarding** — creating and organising Grafana dashboards: panels,
+  variables, transformations, and thresholds.
+
+## Example requests
+
+```text
+Discover the HTTP metrics available in Prometheus matching http_.*
+Write a PromQL query for the p99 request latency per endpoint
+Create a RED-method dashboard for the checkout service
+Deploy that dashboard to my Grafana Cloud instance
+```
+
+Submit any of these with the A2A Debugger:
+
+```bash
+docker run --rm -it --network host \
+  ghcr.io/inference-gateway/a2a-debugger:latest \
+  --server-url http://localhost:8080 \
+  tasks submit "Create a RED-method dashboard for the checkout service"
+```
+
+For a runnable end-to-end demo — including a Prometheus instance with live
+metrics and a pre-provisioned Grafana — see the
+[docker-compose example](../examples/docker-compose/README.md).


### PR DESCRIPTION
## Summary

Adds `spec.examples` (4 entries) and `spec.documentation.pages` to `agent.yaml` (supported by the ADL v0.49.0 schema but never authored, since `adl init --defaults` skips them), plus the referenced hand-written docs pages, and regenerates the README so the new sections render.

### spec.examples (title + description)
Discover metrics, build & validate PromQL, create a Grafana dashboard, deploy a dashboard — mapped to the agent's real tools/skills.

### spec.documentation.pages (docs/)
- `docs/getting-started.md` — run the agent, connect an LLM/Prometheus/Grafana, first request
- `docs/configuration.md` — the env vars this agent reads (LLM client, `GRAFANA_*`, and the `prometheus_url` / `PROMETHEUS_URL` default)
- `docs/usage.md` — the discover -> query -> build -> deploy workflow, tools, and skills

### Validation
- `adl validate agent.yaml` passes
- Regeneration was idempotent — only `README.md` and `agent.yaml` changed (no code/go.mod churn)
- `spec.tools`, `spec.skills`, `spec.config`, and `spec.services` are unchanged

Closes #84

Generated with [Claude Code](https://claude.ai/code)
